### PR TITLE
prevent plugin choking if request comes from console

### DIFF
--- a/mailer/MailerPlugin.php
+++ b/mailer/MailerPlugin.php
@@ -72,11 +72,13 @@ class MailerPlugin extends BasePlugin
 		parent::init();
 		
 		//Include plugin JS
-        if (craft()->request->isCpRequest() && craft()->request->getSegment(1) == 'mailer') {
-			craft()->templates->includeJsFile( UrlHelper::getResourceUrl('mailer/mailer.js') );
+        if(!craft()->isConsole()){
+            if (craft()->request->isCpRequest() && craft()->request->getSegment(1) == 'mailer') {
+    			craft()->templates->includeJsFile( UrlHelper::getResourceUrl('mailer/mailer.js') );
 
-            craft()->log->removeRoute('WebLogRoute');
-            craft()->log->removeRoute('ProfileLogRoute');
+                craft()->log->removeRoute('WebLogRoute');
+                craft()->log->removeRoute('ProfileLogRoute');
+            }
         }
 	}
 	


### PR DESCRIPTION
Hi Victor,

I ran into trouble earlier when I was trying to run a yiic console command with Mailer installed. The error was in the init() function. I've just wrapped it in if statement to prevent the error.
